### PR TITLE
Add --progress flag

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -10,14 +10,13 @@ git clone https://github.com/dm-vdo/kvdo
 
 Build the uds library:
 ~~~
-cd   $BUILD_DIR/kvdo
-make -C /usr/src/kernels/`uname -r` M=`pwd`
+make -C $BUILD_DIR/vdo/utils/uds/
 ~~~
 
 Get and build the LZ4 library:
 ~~~
 git clone https://github.com/lz4/lz4
-make -C $BUILD_DIR/lz4/ lib
+make -C $BUILD_DIR/lz4/lib/
 ~~~
 
 Get and build vdoestimator:

--- a/BUILD.md
+++ b/BUILD.md
@@ -10,13 +10,14 @@ git clone https://github.com/dm-vdo/kvdo
 
 Build the uds library:
 ~~~
-make -C $BUILD_DIR/vdo/utils/uds/
+cd   $BUILD_DIR/kvdo
+make -C /usr/src/kernels/`uname -r` M=`pwd`
 ~~~
 
 Get and build the LZ4 library:
 ~~~
 git clone https://github.com/lz4/lz4
-make -C $BUILD_DIR/lz4/lib/
+make -C $BUILD_DIR/lz4/ lib
 ~~~
 
 Get and build vdoestimator:

--- a/HowToRun.md
+++ b/HowToRun.md
@@ -19,6 +19,7 @@ There are several options one can use in vdoestimator:
     --help            Print this help message and exit
     --index           Specify the location and name of the UDS index file (required)
     --memorySize      Specifies the amount of UDS server memory in gigabytes (the default size is 0.25 GB). The special decimal values 0.25, 0.5 and 0.75 can be used as can any positive integer up to 1024.
+    --progress        Print scan progress in interval
     --reuse           Reuse an existing index file
     --sparse          Use a sparse index
     --verbose         Verbose run

--- a/HowToRun.md
+++ b/HowToRun.md
@@ -1,0 +1,58 @@
+
+The purpose of vdoestimator is to estimate how much space VDO can save
+on your server before you install and run it. vdoestimator can also be
+used to test whether or not your dedupe rate will be affected by using
+different memory size and also indicate which type of index to use.
+
+Usage:
+
+./vdoestimator --index Index_File DataLocation
+
+There are several options one can use in vdoestimator:
+
+  vdoestimator  --help
+  vdoestimator [OPTION]... dataPATH
+
+  Options:
+    --compressionOnly Calculate compression only saving
+    --dedupeOnly      Calculate deduplication
+    --help            Print this help message and exit
+    --index           Specify the location and name of the UDS index file (required)
+    --memorySize      Specifies the amount of UDS server memory in gigabytes (the default size is 0.25 GB). The special decimal values 0.25, 0.5 and 0.75 can be used as can any positive integer up to 1024.
+    --reuse           Reuse an existing index file
+    --sparse          Set index file to sparse
+    --verbose         Verbose run
+
+There are two required arguments:
+    --index   Specify the location and name of the UDS index file
+    dataPath  Where your data is.  This can also be a block device.
+
+Changing the memorySize or sparse index may indicate a better storage
+savings rate.  Please refer to VDO documentation for the effect of
+changing these parameters.
+
+Example:
+
+The vdoestimator output is fairly self explanatory. The important
+numbers to look at are the dedupe percentage, percent saved
+compression and total percent saved.  The below output example
+represents a scan of approximately 500G of storage that contains test
+data. If this data was stored on VDO, it would realize a savings of
+approximately 72%.
+
+Duration: 1h:31m:1s
+Sparse Index: 0
+Files Scanned: 2419506
+Files Skipped: 0
+Bytes Scanned: 510717808354
+Entries Indexed: 35572176
+Dedupe Request Posts Found: 83450727
+Dedupe Request Posts Not Found: 42687679
+Dedupe Percentage: 66.158%
+Compressed Bytes: 31618975088
+Percent Saved Compression: 6.191%
+Total Bytes Used: 141808225265
+Total Percent Saved: 72.234%
+Peak Concurrent Requests: 2000
+Estimate Index Size: 72.234M
+

--- a/vdoestimator.c
+++ b/vdoestimator.c
@@ -288,17 +288,17 @@ static void usage(char *prog)
          "device.\n"
          "\n"
          "Options:\n"
-	 "  --compressionOnly Calculate compression only saving\n"
-	 "  --dedupeOnly      Calculate dedupe only saving\n"
+         "  --compressionOnly Calculate compression only saving\n"
+         "  --dedupeOnly      Calculate dedupe only saving\n"
          "  --help            Print this help message and exit\n"
-	 "  --index           Specify location and name of the UDS index file\n"
-	 "  --memorySize      Specifies the amount of UDS server memory in gigabytes;\n"
+         "  --index           Specify location and name of the UDS index file\n"
+         "  --memorySize      Specifies the amount of UDS server memory in gigabytes;\n"
          "                    the default size is 0.25 GB.\n"
-	 "                    The special decimal values 0.25, 0.5, 0.75 can be used\n"
-	 "                    as can any positive integer up to 1024.\n"
-	 "  --reload          Reload index file\n"
-	 "  --sparse          Set index file to sparse\n"
-	 "  --verbose         Verbose run\n",
+         "                    The special decimal values 0.25, 0.5, 0.75 can be used\n"
+         "                    as can any positive integer up to 1024.\n"
+         "  --reload          Reload index file\n"
+         "  --sparse          Set index file to sparse\n"
+         "  --verbose         Verbose run\n",
          prog);
 }
 

--- a/vdoestimator.c
+++ b/vdoestimator.c
@@ -198,11 +198,11 @@ static void scan(char *file, UdsBlockContext context)
     query->data_size = nread;
     total_bytes += nread;
     query->request = (struct udsRequest) {.callback  = chunk_callback,
-					  .context   = context,
-					  .type      = UDS_POST,
+                                          .context   = context,
+                                          .type      = UDS_POST,
     };
     MurmurHash3_x64_128 (query->data, nread, 0x62ea60be,
-			 &query->request.chunkName);
+                         &query->request.chunkName);
     int result = udsStartChunkOperation(&query->request);
     if (result != UDS_SUCCESS) {
       errx(1, "Unable to start request");

--- a/vdoestimator.c
+++ b/vdoestimator.c
@@ -74,7 +74,8 @@ static char *uds_index = NULL;
 static bool use_sparse = false;
 static bool compression_only = false;
 static bool dedupe_only = false;
-static bool reload = false;
+static bool reuse = false;
+static bool mem_modified = false;
 static bool verbose = false;
 UdsMemoryConfigSize mem_size;
 
@@ -290,14 +291,14 @@ static void usage(char *prog)
          "\n"
          "Options:\n"
          "  --compressionOnly Calculate compression only saving\n"
-         "  --dedupeOnly      Calculate dedupe only saving\n"
+         "  --dedupeOnly      Calculate deduplication\n"
          "  --help            Print this help message and exit\n"
-         "  --index           Specify location and name of the UDS index file\n"
+         "  --index           Specify the location and name of the UDS index file\n"
          "  --memorySize      Specifies the amount of UDS server memory in gigabytes;\n"
          "                    the default size is 0.25 GB.\n"
          "                    The special decimal values 0.25, 0.5, 0.75 can be used\n"
          "                    as can any positive integer up to 1024.\n"
-         "  --reload          Reload index file\n"
+         "  --reuse           Reuse index file\n"
          "  --sparse          Set index file to sparse\n"
          "  --verbose         Verbose run\n",
          prog);
@@ -313,7 +314,7 @@ static int parse_args(int argc, char *argv[])
        {"help",             no_argument,       0,    'h'},
        {"index",            required_argument, 0,    'i'},
        {"memorySize",       required_argument, 0,    'm'},
-       {"reload",           no_argument,       0,    'r'},
+       {"reuse",            no_argument,       0,    'r'},
        {"sparse",           no_argument,       0,    's'},
        {"verbose",          no_argument,       0,    'v'},
        {0,                  0,                 0,     0 }
@@ -337,6 +338,7 @@ static int parse_args(int argc, char *argv[])
       uds_index = optarg;
       break;
     case 'm':
+      mem_modified = true;
       if (strcmp("0.25", optarg) == 0)
         mem_size = UDS_MEMORY_CONFIG_256MB;
       else if (strcmp("0.5", optarg) == 0)
@@ -354,7 +356,7 @@ static int parse_args(int argc, char *argv[])
       }
       break;
     case 'r':
-      reload = true;
+      reuse = true;
       break;
     case 's':
       use_sparse = true;
@@ -382,6 +384,11 @@ static int parse_args(int argc, char *argv[])
     printf("Option conflict, please only use -c or -d\n");
     _exit(2);
   }
+  if (reuse && (mem_modified || use_sparse)) {
+    printf("Option conflict, cannot reuse index file ");
+    printf("while memory or index file style changed\n");
+    _exit(2);
+  }
 }
 
 int main(int argc, char *argv[])
@@ -399,10 +406,10 @@ int main(int argc, char *argv[])
   udsConfigurationSetSparse(conf, use_sparse);
 
   UdsIndexSession session;
-  if (reload) {
+  if (reuse) {
     result = udsLoadLocalIndex(uds_index, &session);
     if (result != UDS_SUCCESS) {
-      errx(1, "Unable to reload local index");
+      errx(1, "Unable to reuse local index");
     }
   } else {
     result = udsCreateLocalIndex(uds_index, conf, &session);
@@ -456,23 +463,23 @@ int main(int argc, char *argv[])
   printf("Duration: %dh:%dm:%ds\n",
          time_passed/3600, (time_passed%3600)/60, time_passed%60);
   printf("Sparse Index: %d\n", udsConfigurationGetSparse(conf));
-  printf("Files scanned: %lu\n", files_scanned);
-  printf("Files skipped: %lu\n", files_skipped);
-  printf("Bytes scanned: %lu\n", total_bytes);
-  printf("Entries indexed: %lu\n", stats.entriesIndexed);
-  printf("Dedupe Request Posts found: %lu\n", cstats.postsFound);
-  printf("Dedupe Request Posts not found: %lu\n", cstats.postsNotFound);
+  printf("Files Scanned: %lu\n", files_scanned);
+  printf("Files Skipped: %lu\n", files_skipped);
+  printf("Bytes Scanned: %lu\n", total_bytes);
+  printf("Entries Indexed: %lu\n", stats.entriesIndexed);
+  printf("Dedupe Request Posts Found: %lu\n", cstats.postsFound);
+  printf("Dedupe Request Posts Not Found: %lu\n", cstats.postsNotFound);
   printf("Dedupe Percentage: %2.3f%%\n",
          ((double)cstats.postsFound/(double)cstats.requests) * 100);
   double saved
      = (double)compressed_bytes / (double)total_bytes;
-  printf("Compressed bytes: %lu\n", compressed_bytes);
-  printf("Percent saved compression: %2.3f%%\n", saved * 100.0);
-  printf("Total bytes used: %lu\n", bytes_used);
+  printf("Compressed Bytes: %lu\n", compressed_bytes);
+  printf("Percent Saved Compression: %2.3f%%\n", saved * 100.0);
+  printf("Total Bytes Used: %lu\n", bytes_used);
   saved = ((double)total_bytes - (double)bytes_used) / (double)total_bytes; 
-  printf("Total percent saved: %2.3f%%\n", saved * 100.0);
-  printf("Peak concurrent requests: %u\n", peak_requests);
-  printf("Estimate index size: %luM\n", stats.diskUsed/(1024*1024));
+  printf("Total Percent Saved: %2.3f%%\n", saved * 100.0);
+  printf("Peak Concurrent Requests: %u\n", peak_requests);
+  printf("Estimate Index Size: %luM\n", stats.diskUsed/(1024*1024));
 
   result = udsCloseBlockContext(context);
   if (result != UDS_SUCCESS) {


### PR DESCRIPTION

--verbose can be too much data, add --progress flag to print progress at certain time internal.
It will print the current file that is being processed and total bytes that have been scanned at certain interval.  Printing the total bytes scanned allow us to know we are still making progress even if we are process a large file.  
