### PR TITLE
Fix dedup stat bug, using flush instead of suspend.  Also, add runTest to vdoestimator to test dedup rate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ PROGS = vdoestimator
 
 SUBPROGS = lz4 uds
 
-all: third $(PROGS)
+all: third $(PROGS) test
 
 clean:
 	$(RM) $(PROGS) $(OBJECTS)
@@ -75,5 +75,9 @@ uds: download
 
 vdoestimator: $(OBJECTS) $(DEPLIBS)
 	$(CC) -o $@ $(OBJECTS) $(CDEBUGFLAGS) $(LDFLAGS)
+
+test:
+	echo "Run vdoestimator test"
+	./runTest
 
 .PHONY = install clean

--- a/runTest
+++ b/runTest
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+minDedup=85
+function cleanUp {
+ rm -rf testDir test.index
+}
+
+function runVDOEstimator {
+  sync
+  ./vdoestimator --index test.index ./testDir
+}
+
+cleanUp
+mkdir testDir
+dd if=/dev/zero ibs=4k count=22 > testDir/data 2>/dev/null
+dedupPercent=`runVDOEstimator | grep 'Dedupe Percentage' | awk '{print $3}' | sed 's/%//'`
+dedupPercent=${dedupPercent/\.*}
+if [ $dedupPercent -lt $minDedup ]; then
+  echo Dedup too low: $dedupPercent
+  exit 1  
+else
+  echo succeed: $dedupPercent
+fi
+
+dedup1=$dedupPercent
+
+cleanUp
+mkdir testDir
+dd if=/dev/zero ibs=4k count=22 2>/dev/null | tr "\000" "\377" > testDir/data 
+dedupPercent=`runVDOEstimator | grep 'Dedupe Percentage' | awk '{print $3}' | sed 's/%//'`
+dedupPercent=${dedupPercent/\.*}
+if [ $dedupPercent -lt $minDedup ]; then
+  echo Dedup too low: $dedupPercent
+  exit 1
+else
+  echo succeed: $dedupPercent
+fi
+dedup2=$dedupPercent
+
+if [ $dedup1 != $dedup2 ]; then
+  echo Dedup rate should be the same for the first two tests.
+  exit 1;
+fi
+  
+cleanUp
+mkdir testDir
+dd if=/dev/zero ibs=4k count=11 >  testDir/data 2>/dev/null
+dd if=/dev/zero ibs=4k count=11 2>/dev/null | tr "\000" "\377" >> testDir/data 2>/dev/null
+dedupPercent=`runVDOEstimator | grep 'Dedupe Percentage' | awk '{print $3}' | sed 's/%//'`
+dedupPercent=${dedupPercent/\.*}
+if [ $dedupPercent -lt $minDedup ]; then
+  echo Dedup too low: $dedupPercent
+  exit 1  
+else
+  echo succeed: $dedupPercent
+fi
+
+cleanUp
+exit 0
+

--- a/vdoestimator.c
+++ b/vdoestimator.c
@@ -437,10 +437,10 @@ int main(int argc, char *argv[])
     }
   }
 
-  result = udsSuspendIndexSession(session, 0);
-  if (result != UDS_SUCCESS) {
-    errx(1, "Unable to suspend the index session");
-  }
+  result = udsFlushIndexSession(session);
+   if (result != UDS_SUCCESS) {
+     errx(1, "Unable to flush the index session");
+   }
 
   struct udsContextStats cstats;
   result = udsGetIndexSessionStats(session, &cstats);


### PR DESCRIPTION

udsFlushIndexSession will flush the stat so we get proper dedup number.

