### PR TITLE
Enable Travis CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: c
+os: linux
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,13 @@ SUBPROGS = lz4 uds
 
 all: third $(PROGS)
 
+test: all
+	./runTest
+
 clean:
 	$(RM) $(PROGS) $(OBJECTS)
+
+dist-clean:
 	$(RM) -r $(BUILDROOT)
 
 download:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vdoestimator
 
 This is a tool to estimate space savings from the dm-vdo device mapper
-device
+device.
 
 # DEPENDENCIES
 This project requires gcc to be installed.
@@ -12,6 +12,12 @@ This project also requires the UDS software as well as LZ4 compression software 
 To build vdoestimator and all of the projects to which it depends, run:
 ~~~
 make
+~~~
+
+# TESTING
+To run a smoke test:
+~~~
+make test
 ~~~
 
 # INSTALLING


### PR DESCRIPTION
This change enables Travis CI testing.
It also separates "make clean" into "make clean" that just removes vdoestimator objects and "make dist-clean" which also removes the downloaded dependencies.